### PR TITLE
fix: Optimize the display of NFT transaction information

### DIFF
--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -115,3 +115,5 @@ pub const NETWORK_READ_TIMEOUT: u16 = 30;
 pub const ETH_TRANSACTION_TYPE_LEGACY: &str = "00";
 pub const ETH_TRANSACTION_TYPE_EIP2718: &str = "01";
 pub const ETH_TRANSACTION_TYPE_EIP1559: &str = "02";
+
+pub const ETH_MAX_SUPPORT_PAYMENT_LEN: usize = 255;

--- a/wallet/coin-ethereum/src/transaction.rs
+++ b/wallet/coin-ethereum/src/transaction.rs
@@ -84,13 +84,7 @@ impl Transaction {
             data_pack.extend([7, payment.as_bytes().len() as u8].iter());
             data_pack.extend(payment.as_bytes().iter());
         } else {
-            data_pack.extend(
-                [
-                    7,
-                    payment[..constants::ETH_MAX_SUPPORT_PAYMENT_LEN].len() as u8,
-                ]
-                .iter(),
-            );
+            data_pack.extend([7, constants::ETH_MAX_SUPPORT_PAYMENT_LEN as u8].iter());
             data_pack.extend(
                 payment[..constants::ETH_MAX_SUPPORT_PAYMENT_LEN]
                     .as_bytes()


### PR DESCRIPTION
Optimize the display of NFT transaction information（Truncate the first 255 bytes）
[[NFT-Phase1-遗留] 转账比较长name的nft，imkey上显示和按钮提示重叠了](https://imtoken.atlassian.net/browse/R2D2-5276)